### PR TITLE
Slimming: remove Japanese Sudachi payload and fix duplicate requests

### DIFF
--- a/CDMF.spec
+++ b/CDMF.spec
@@ -323,6 +323,11 @@ a = Analysis(
     excludes=[
         # Note: matplotlib is used by some dependencies but excluded to reduce bundle size
         # If you encounter import errors, remove this exclusion
+        # Slimming: exclude Japanese Sudachi packages (large dictionary payload; not needed)
+        'sudachipy',
+        'sudachidict_core',
+        'sudachidict_small',
+        'sudachidict_full',
     ],
     win_no_prefer_redirects=False,
     win_private_assemblies=False,

--- a/build_local.sh
+++ b/build_local.sh
@@ -71,6 +71,14 @@ echo "[Build] Installing additional dependencies..."
 "$PY" -m pip install "git+https://github.com/ace-step/ACE-Step.git" --no-deps --quiet
 "$PY" -m pip install "rotary_embedding_torch" --quiet
 
+# ---------------------------------------------------------------------------
+# Slimming: remove Japanese (Sudachi) dictionary payload
+# SudachiDict-core is ~200MB and not needed for AceForge.
+# We explicitly uninstall it (and SudachiPy) so PyInstaller cannot bundle it.
+# ---------------------------------------------------------------------------
+echo "[Build] Removing Japanese Sudachi packages (if present)..."
+"$PY" -m pip uninstall -y SudachiDict-core SudachiPy sudachidict-core sudachipy >/dev/null 2>&1 || true
+
 # Install TTS for voice cloning (required for frozen app; build fails if TTS cannot be imported)
 # TTS 0.21.2 needs its full dependency tree (phonemizers etc.); --no-deps breaks "from TTS.api import TTS"
 echo "[Build] Installing TTS for voice cloning..."
@@ -119,6 +127,10 @@ fi
 
 echo "[Build] PyInstaller version: $("$PY" -m PyInstaller --version)"
 echo ""
+
+# One last pass right before bundling, in case anything reintroduced Sudachi.
+echo "[Build] Final check: removing Japanese Sudachi packages (if present)..."
+"$PY" -m pip uninstall -y SudachiDict-core SudachiPy sudachidict-core sudachipy >/dev/null 2>&1 || true
 
 # Clean previous builds (PyInstaller outputs only).
 # NEVER delete build/macos/ — it contains AceForge.icns (app icon), codesign.sh, pyinstaller hooks.

--- a/static/scripts/cdmf_generation_ui.js
+++ b/static/scripts/cdmf_generation_ui.js
@@ -419,6 +419,14 @@
   function onSubmitForm(ev) {
     const state = getState();
 
+    // Prevent duplicate submissions (double-click protection)
+    if (state.candyIsGenerating || window.candyIsGenerating) {
+      if (ev && ev.preventDefault) {
+        ev.preventDefault();
+      }
+      return false;
+    }
+
     // If the ACE model is not ready yet, repurpose this submit as
     // a "Download Models" action instead of sending /generate.
     if (!state.candyModelsReady) {


### PR DESCRIPTION
- Remove SudachiDict-core (~200MB) and SudachiPy from build
- Add PyInstaller excludes to prevent bundling Japanese packages
- Fix duplicate generation request bug (double-click protection)
- App size reduced from 1.3GB to 1.1GB